### PR TITLE
Added option "nonCssFileSelectors" - Option to replaces CSS classes or IDs that is not present into the CSS file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+.idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
 
     revizor: {
       options: {
-        namePrefix: '--',
+        nameSuffix: '__',
         compressFilePrefix: '-rvz',
         flatten: false
       },

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # grunt-revizor
 
 > Grunt plugin for compression CSS classes and identifiers.
-Exmaple: `.b-tabmenu--item__active--` -> `.zS`, `#success_info--` -> `.e6`
+Exmaple: `.b-tabmenu__item--active__` -> `.zS`, `#success_info__` -> `.e6`
 
 ## Getting Started
 This plugin requires Grunt `~0.4.5`
@@ -9,7 +9,7 @@ This plugin requires Grunt `~0.4.5`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-revizor --save-dev
+npm install grunt-revizor __save-dev
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
@@ -22,10 +22,10 @@ grunt.loadNpmTasks('grunt-revizor');
 
 #### options.namePrefix
 Type: `String`
-Default value: `'--'`
+Default value: `'__'`
 
 Prefix to which end the class names and identifiers to be compressed
-Exmaple: `.b-tabmenu--item__active--` -> `.zS`
+Exmaple: `.b-tabmenu__item--active__` -> `.zS`
 
 #### options.compressFilePrefix
 Type: `String`
@@ -80,7 +80,7 @@ grunt.initConfig({
 });
 ```
 The result is a new compressed files in the same directory specified in the src, with a standard prefix.
-Name compress example: `.b-tabmenu--item__active--` -> `.zS`
+Name compress example: `.b-tabmenu__item--active__` -> `.zS`
 Example: `test/css/style1-min.css`, `test/css/style2-min.css`, `test/html/index-min.html`
 
 
@@ -118,7 +118,7 @@ Example: `build/test/css/style1-min.css`, `build/test/css/style2-min.css`, `test
 grunt.initConfig({
   revizor: {
     options: {
-        namePrefix: '__',
+        namePrefix: '--',
         compressFilePrefix: '.min'
     },
     src: ['test/css/*.css', 'test/html/*.html', 'test/js/*.js'],
@@ -126,8 +126,8 @@ grunt.initConfig({
   },
 });
 ```
-The result is a new compressed files in the directory `build`, with the prefix `.min`. Will compress all names that end with symbols `__`.
-Name compress example: `.b-tabmenu__item--active__` -> `.xS`
+The result is a new compressed files in the directory `build`, with the prefix `.min`. Will compress all names that end with symbols `--`.
+Name compress example: `.b-tabmenu--item__active--` -> `.xS`
 File path example: `build/style1.min.css`, `build/style2.min.css`, `build/index.min.html`
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -34,6 +34,33 @@ Default value: `'-min'`
 The prefix for the name of the compressed file. The final name of the new file is equal to the original file name plus a prefix plus the extension of the original file.
 Example: `style1.css` -> `style-min.css`
 
+#### options.nonCssFileSelectors
+Type: `Array`
+Default value: []
+
+By default grunt-revizor minifies only classes and IDs that exist within your CSS files. We do this to avoid replace
+strings by mistake from your non-css files (like JS, PHP, HTML, etc).
+But sometimes there are CSS classes and IDs that exists only within non-css files. It happens, for example, when you 
+create a CSS ID only because you need to find that element from within a JS code. Example: `$(#some-selector)`    
+Often these selectors are not referenced in your CSS causing grunt-revizor to ignore them.
+
+Use this option to let grunt-revizor know which are the CSS class and IDs that should be minified even that it is not present in your CSS file.
+Using this option grunt-revizor can safe minify selectors inside your no-css files without make a mistake.
+
+```js
+grunt.initConfig({
+  revizor: {
+    options: {
+      nonCssFileSelectors: [
+        '#select-one',
+        '.selector-two'
+      ]
+    },
+    src: ['test/css/*.css', 'test/html/*.html', 'test/js/*.js']
+  },
+});
+```
+
 #### options.flatten
 Type: `Boolean`
 Default value: `true`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin requires Grunt `~0.4.5`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-revizor __save-dev
+npm install grunt-revizor --save-dev
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ grunt.loadNpmTasks('grunt-revizor');
 
 ### Options
 
-#### options.namePrefix
+#### options.nameSuffix
 Type: `String`
 Default value: `'__'`
 
@@ -49,7 +49,7 @@ Using this option grunt-revizor can safe minify selectors inside your no-css fil
 
 You can also use this option to minify string that are not CSS classes selectors. Be creative ;)
 
-You don't need to add the dot nor the # in the begin of the strings in this array, nor you need to add the `options.namePrefix`
+You don't need to add the dot nor the # in the begin of the strings in this array, nor you need to add the `options.nameSuffix`
 in it. The grunt-revizor is smart enough to add it for you automatically.
 
 ```js
@@ -73,7 +73,7 @@ All these strings are equivalents.
 grunt.initConfig({
   revizor: {
     options: {
-      namePrefix: '__',
+      nameSuffix: '__',
       nonCssFileSelectors: [
         '#selector',
         '.selector',
@@ -98,7 +98,7 @@ Set `false` if you want to save the directory structure
 Type: `Boolean`
 Default value: `false`
 
-Set `true` if you want to be notified about strings that match the prefix configured in `options.namePrefix` but 
+Set `true` if you want to be notified about strings that match the prefix configured in `options.nameSuffix` but 
 were ignored by grunt-revizor.   
 An string will be ignored when it is not found inside your CSS files nether in the array `options.nonCssFileSelectors`.   
 Read the documentation about `options.nonCssFileSelectors` for more details.
@@ -150,12 +150,12 @@ grunt.initConfig({
 The result is a new compressed files in the directory `build`, with a standard prefix.
 Example: `build/test/css/style1-min.css`, `build/test/css/style2-min.css`, `test/html/index-min.html`
 
-#### Custom namePrefix and filePrefix
+#### Custom nameSuffix and filePrefix
 ```js
 grunt.initConfig({
   revizor: {
     options: {
-        namePrefix: '--',
+        nameSuffix: '--',
         compressFilePrefix: '.min'
     },
     src: ['test/css/*.css', 'test/html/*.html', 'test/js/*.js'],

--- a/README.md
+++ b/README.md
@@ -47,13 +47,40 @@ Often these selectors are not referenced in your CSS causing grunt-revizor to ig
 Use this option to let grunt-revizor know which are the CSS class and IDs that should be minified even that it is not present in your CSS file.
 Using this option grunt-revizor can safe minify selectors inside your no-css files without make a mistake.
 
+You can also use this option to minify string that are not CSS classes selectors. Be creative ;)
+
+You don't need to add the dot nor the # in the begin of the strings in this array, nor you need to add the `options.namePrefix`
+in it. The grunt-revizor is smart enough to add it for you automatically.
+
 ```js
 grunt.initConfig({
   revizor: {
     options: {
       nonCssFileSelectors: [
-        '#select-one',
-        '.selector-two'
+        '#selector-one',
+        '.selector-two',
+        'selector-three',
+        'a-non-css-class-string',
+      ]
+    },
+    src: ['test/css/*.css', 'test/html/*.html', 'test/js/*.js']
+  },
+});
+```
+
+All these strings are equivalents.   
+```js
+grunt.initConfig({
+  revizor: {
+    options: {
+      namePrefix: '__',
+      nonCssFileSelectors: [
+        '#selector',
+        '.selector',
+        '.selector__',
+        '#selector__',
+        'selector__',
+        'selector',
       ]
     },
     src: ['test/css/*.css', 'test/html/*.html', 'test/js/*.js']

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ Default value: `true`
 
 Set `false` if you want to save the directory structure
 
+#### options.reportNotMinifiedSelectors
+Type: `Boolean`
+Default value: `false`
+
+Set `true` if you want to be notified about strings that match the prefix configured in `options.namePrefix` but 
+were ignored by grunt-revizor.   
+An string will be ignored when it is not found inside your CSS files nether in the array `options.nonCssFileSelectors`.   
+Read the documentation about `options.nonCssFileSelectors` for more details.
+
+
 ### Usage Examples
 
 #### Default Options

--- a/tasks/revizor.js
+++ b/tasks/revizor.js
@@ -25,6 +25,7 @@ module.exports = function(grunt) {
     options = this.options({
       namePrefix: '__',
       flatten: true,
+      nonCssFileSelectors: [],
       compressFilePrefix: '-min'
     });
 
@@ -51,6 +52,7 @@ module.exports = function(grunt) {
       compressCssNames(fileData);
     });
 
+    compressNonCssFileNames();
     filesForCompress.forEach(function(filepath) {
       var newFileData = compressFile(filepath);
       saveCompressedFile(newFileData, filepath);
@@ -69,6 +71,15 @@ module.exports = function(grunt) {
         name = name.substring(1, name.length);
         if (compressedNames[name] === undefined) {
           compressedNames[name] = getRandomStr();
+        }
+      });
+    }
+
+    function compressNonCssFileNames () {
+      options.nonCssFileSelectors.forEach(function (selector) {
+        selector = selector.substring(1, selector.length);
+        if (compressedNames[selector] === undefined) {
+          compressedNames[selector] = getRandomStr();
         }
       });
     }

--- a/tasks/revizor.js
+++ b/tasks/revizor.js
@@ -24,12 +24,17 @@ module.exports = function(grunt) {
 
 
     options = this.options({
-      namePrefix: '__',
+      nameSuffix: '__',
       flatten: true,
       nonCssFileSelectors: [],
       reportNotMinifiedSelectors: false,
       compressFilePrefix: '-min'
     });
+
+    if (options.namePrefix) {
+      options.nameSuffix = options.namePrefix;
+      delete options.namePrefix;
+    }
 
     function escapeRegExp(string){
       // From Mozilla Developer Network
@@ -38,7 +43,7 @@ module.exports = function(grunt) {
       return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
     };
     
-    var namePrefixRegExpEscaped = escapeRegExp(options.namePrefix);
+    var nameSuffixRegExpEscaped = escapeRegExp(options.nameSuffix);
     
     firstCharList = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
     OtherCharsList = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_';
@@ -75,7 +80,7 @@ module.exports = function(grunt) {
       var
         namePattern,
         result;
-      namePattern = new RegExp('(\\.|#)[A-Za-z0-9_-]+' + options.namePrefix, 'g');
+      namePattern = new RegExp('(\\.|#)[A-Za-z0-9_-]+' + options.nameSuffix, 'g');
       result = fileData.match(namePattern);
       if (result === null) { return; }
       result.forEach(function (name) {
@@ -92,9 +97,9 @@ module.exports = function(grunt) {
         selector = selector.replace(/^[\.#]/, '');
         
         // Add string suffix if it does not has yet.
-        var regExp = new RegExp(namePrefixRegExpEscaped + '$');
+        var regExp = new RegExp(nameSuffixRegExpEscaped + '$');
         if (!selector.match(regExp)) {
-          selector += options.namePrefix;
+          selector += options.nameSuffix;
         }
         
         if (compressedNames[selector] === undefined) {
@@ -110,7 +115,7 @@ module.exports = function(grunt) {
         namePattern;
 
       fileData = grunt.file.read(filepath);
-      namePattern = new RegExp('[A-Za-z0-9_-]+' + options.namePrefix, 'g');
+      namePattern = new RegExp('[A-Za-z0-9_-]+' + options.nameSuffix, 'g');
       newFileData = fileData.replace(namePattern, function (name) {
         if (options.reportNotMinifiedSelectors && !compressedNames[name] && !notFound[name]) {
           notFound[name] = true;

--- a/tasks/revizor.js
+++ b/tasks/revizor.js
@@ -19,6 +19,7 @@ module.exports = function(grunt) {
       destDir = this.data.dest || null,
       firstCharList,
       OtherCharsList,
+      notFound = {},
       options;
 
 
@@ -26,6 +27,7 @@ module.exports = function(grunt) {
       namePrefix: '__',
       flatten: true,
       nonCssFileSelectors: [],
+      reportNotMinifiedSelectors: false,
       compressFilePrefix: '-min'
     });
 
@@ -93,6 +95,10 @@ module.exports = function(grunt) {
       fileData = grunt.file.read(filepath);
       namePattern = new RegExp('[A-Za-z0-9_-]+' + options.namePrefix, 'g');
       newFileData = fileData.replace(namePattern, function (name) {
+        if (options.reportNotMinifiedSelectors && !compressedNames[name] && !notFound[name]) {
+          notFound[name] = true;
+          console.log("Selector not minified: " + name);
+        }
         return compressedNames[name] ? compressedNames[name] : name;
       });
       return newFileData;

--- a/tasks/revizor.js
+++ b/tasks/revizor.js
@@ -31,6 +31,15 @@ module.exports = function(grunt) {
       compressFilePrefix: '-min'
     });
 
+    function escapeRegExp(string){
+      // From Mozilla Developer Network
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions?redirectlocale=en-US&redirectslug=JavaScript%2FGuide%2FRegular_Expressions
+
+      return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+    };
+    
+    var namePrefixRegExpEscaped = escapeRegExp(options.namePrefix);
+    
     firstCharList = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
     OtherCharsList = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_';
 
@@ -79,7 +88,15 @@ module.exports = function(grunt) {
 
     function compressNonCssFileNames () {
       options.nonCssFileSelectors.forEach(function (selector) {
-        selector = selector.substring(1, selector.length);
+        // Remove first character if it is an dot or #.
+        selector = selector.replace(/^[\.#]/, '');
+        
+        // Add string suffix if it does not has yet.
+        var regExp = new RegExp(namePrefixRegExpEscaped + '$');
+        if (!selector.match(regExp)) {
+          selector += options.namePrefix;
+        }
+        
         if (compressedNames[selector] === undefined) {
           compressedNames[selector] = getRandomStr();
         }


### PR DESCRIPTION
I now grunt-revizor minifies only classes and IDs that exist within your CSS files.
I think it is to avoid replace strings by mistake from non-css files (like JS, PHP, HTML, etc). 

But sometimes there are CSS classes and IDs that exists only within non-css files. It happens, for example, when you create a CSS ID only because you need to find that element from within a JS code. Example: $(#some-selector) Often these selectors are not referenced in your CSS causing grunt-revizor to ignore them.

I created a option to let grunt-revizor know which are the CSS class and IDs that should be minified even that it is not present in your CSS file. Using this option grunt-revizor can safe minify selectors inside no-css files without make a mistake.
